### PR TITLE
add interface info for which_children/1

### DIFF
--- a/src/acceptor.erl
+++ b/src/acceptor.erl
@@ -225,7 +225,8 @@ handle_init(Other) ->
 success(Sock, Opts, Parent, #{ack := AckRef} = Data) ->
     case inet:peername(Sock) of
         {ok, PeerName} ->
-            _ = Parent ! {'ACCEPT', self(), AckRef, PeerName},
+            {ok, SockName} = inet:sockname(Sock),
+            _ = Parent ! {'ACCEPT', self(), AckRef, SockName, PeerName},
             continue(Sock, Opts, PeerName, Data);
         {error, Reason} ->
             gen_tcp:close(Sock),

--- a/src/acceptor_pool.erl
+++ b/src/acceptor_pool.erl
@@ -254,10 +254,13 @@ handle_cast(Req, State) ->
 %% @private
 handle_info({'EXIT', Conn, Reason}, State) ->
     handle_exit(Conn, Reason, State);
-handle_info({'ACCEPT', Pid, AcceptRef, PeerName}, State) ->
+handle_info({'ACCEPT', Pid, AcceptRef, SockName, PeerName}, State) ->
     #state{acceptors=Acceptors, conns=Conns} = State,
     case maps:take(Pid, Acceptors) of
-        {{SockRef, SockName, AcceptRef}, NAcceptors} ->
+        %% we ignore the sock name from the acceptor, because it could
+        %% be {0,0,0,0}, and we want to know which interface the
+        %% socket was opened on.
+        {{SockRef, _ListenSockName, AcceptRef}, NAcceptors} ->
             NAcceptors2 = start_acceptor(SockRef, NAcceptors, State),
             NConns = Conns#{Pid => {PeerName, SockName, AcceptRef}},
             {noreply, State#state{acceptors=NAcceptors2, conns=NConns}};


### PR DESCRIPTION
grab the socket name and include it in the information sent to the pool so the user can know which interface a connection is talking on.

another part of #2 